### PR TITLE
Use mainline GPTQ-for-LLaMa

### DIFF
--- a/bandaid.bat
+++ b/bandaid.bat
@@ -9,7 +9,6 @@ mkdir repositories
 cd repositories
 git clone https://github.com/qwopqwop200/GPTQ-for-LLaMa
 cd GPTQ-for-LLaMa
-git reset --hard 468c47c01b4fe370616747b6d69a2d3f48bab5e4
 
 cd ..\..\..
 


### PR DESCRIPTION
Removes, git reset --hard 468c47c01b4fe370616747b6d69a2d3f48bab5e4. It is no longer necessary to use that version of GPTQ. I can't test, but it looks like it's the only change that needs to happen from last night's update.